### PR TITLE
Expose Queue constructor

### DIFF
--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -3,7 +3,7 @@ module Faktory.Settings
   , ConnectionInfo(..)
   , defaultSettings
   , envSettings
-  , Queue
+  , Queue(..)
   , queueArg
   , defaultQueue
   , WorkerId


### PR DESCRIPTION
There's no reason to keep it private, and it is a valid use-case to construct a
Queue from some existing non-literal non-JSON value.