### PR TITLE
Wait 1 second in processorLoop if no job found

### DIFF
--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -73,11 +73,13 @@ processorLoop client queue f = do
 
   mJob <- fetchJob client queue
 
-  for_ mJob $ \job ->
-    processAndAck job `catches`
-      [ Handler $ \(ex :: WorkerHalt) -> throw ex
-      , Handler $ \(ex :: SomeException) -> failJob client job $ T.pack $ show ex
-      ]
+  case mJob of
+    Just job ->
+      processAndAck job `catches`
+        [ Handler $ \(ex :: WorkerHalt) -> throw ex
+        , Handler $ \(ex :: SomeException) -> failJob client job $ T.pack $ show ex
+        ]
+    Nothing -> threadDelay $ 1 * 1000000
 
 -- | <https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#heartbeat>
 heartBeat :: Client -> WorkerId -> IO ()


### PR DESCRIPTION
We noticed high CPU usage in our Faktory consumers when they weren't doing any work. We figured we probably had a tight loop running somewhere.

This PR adds a `threadDelay` of 1 second if no job is found. If a job is found, we don't delay at all and we eagerly try to get the next job (via running `processorLoop` again with `forever`).