### PR TITLE
Throw exceptions from heartbeat to parent thread

### DIFF
--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -6,7 +6,7 @@ where
 
 import Prelude as X
 
-import Control.Concurrent (ThreadId, forkFinally, myThreadId, threadDelay)
+import Control.Concurrent (ThreadId, forkIO, myThreadId, threadDelay)
 import Control.Exception.Safe as X
 import Control.Monad as X
 import Data.Foldable as X
@@ -20,6 +20,4 @@ threadDelaySeconds n = threadDelay $ n * 1000000
 forkIOWithThrowToParent :: IO () -> IO ThreadId
 forkIOWithThrowToParent action = do
   parent <- myThreadId
-  forkFinally action $ \case
-    Left err -> throwTo parent err
-    Right _ -> pure ()
+  forkIO $ action `catch` \(err :: SomeException) -> throwTo parent err

--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -1,11 +1,12 @@
 module Faktory.Prelude
   ( module X
   , module Faktory.Prelude
-  ) where
+  )
+where
 
 import Prelude as X
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (ThreadId, forkFinally, myThreadId, threadDelay)
 import Control.Exception.Safe as X
 import Control.Monad as X
 import Data.Foldable as X
@@ -15,3 +16,10 @@ import Data.Traversable as X
 
 threadDelaySeconds :: Int -> IO ()
 threadDelaySeconds n = threadDelay $ n * 1000000
+
+forkIOWithThrowToParent :: IO () -> IO ThreadId
+forkIOWithThrowToParent action = do
+  parent <- myThreadId
+  forkFinally action $ \case
+    Left err -> throwTo parent err
+    Right _ -> pure ()

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -10,7 +10,7 @@ module Faktory.Worker
 
 import Faktory.Prelude
 
-import Control.Concurrent
+import Control.Concurrent (killThread)
 import Data.Aeson
 import Data.Aeson.Casing
 import qualified Data.Text as T
@@ -58,7 +58,7 @@ runWorker :: FromJSON args => Settings -> Queue -> (args -> IO ()) -> IO ()
 runWorker settings queue f = do
   workerId <- randomWorkerId
   client <- newClient settings $ Just workerId
-  beatThreadId <- forkIO $ forever $ heartBeat client workerId
+  beatThreadId <- forkIOWithThrowToParent $ forever $ heartBeat client workerId
 
   forever (processorLoop client queue f)
     `catch` (\(_ex :: WorkerHalt) -> pure ())


### PR DESCRIPTION
The heartbeat process can fail. This causes its individual thread to
stop, but does not crash the entire process. The threading behavior of
heartbeat should be opaque to users of the library, so an exception
there should throw an exception to the host.

This specifically helps prevent issues where a lost socket is caught and
silenced in the heartbeat and prevents the entire client from crashing.

Addresses #17 