### PR TITLE
Allow failure to occur in job loop

### DIFF
--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -20,4 +20,4 @@ threadDelaySeconds n = threadDelay $ n * 1000000
 forkIOWithThrowToParent :: IO () -> IO ThreadId
 forkIOWithThrowToParent action = do
   parent <- myThreadId
-  forkIO $ action `catch` \(err :: SomeException) -> throwTo parent err
+  forkIO $ action `X.catchAny` \err -> throwTo parent err

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -6,7 +6,8 @@
 module Faktory.Worker
   ( WorkerHalt(..)
   , runWorker
-  ) where
+  )
+where
 
 import Faktory.Prelude
 
@@ -88,11 +89,7 @@ heartBeat client workerId = do
   command_ client "BEAT" [encode $ BeatPayload workerId]
 
 fetchJob :: FromJSON args => Client -> Queue -> IO (Maybe (Job args))
-fetchJob client queue =
-  -- Treat an exception here like no Job. The Client will have already logged
-  -- the protocol error to stderr, and we should just keep chugging.
-  handleAny (const $ pure Nothing)
-    $ commandJSON client "FETCH" [queueArg queue]
+fetchJob client queue = commandJSON client "FETCH" [queueArg queue]
 
 ackJob :: HasCallStack => Client -> Job args -> IO ()
 ackJob client job =


### PR DESCRIPTION
The job loop was swallowing a lot of errors. This happened in two place:
1. Fetching jobs
2. Processing jobs

Fetching was over eager about catching protocol errors. Instead of
preventing failure from protocol and socket errors it should fail. This
prevents bugs in the protocol or operational failures from being
perceived as "no jobs"

Processing jobs was catching errors that could occur in sending an
acknowledgement. They should only be catching all errors for the job
function itself.