### PR TITLE
Add performOnce to enqueue a Job with no retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
             git ls-files | xargs md5sum > digest
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}-{{ checksum "digest" }}
-            - v1-{{ .Branch }}-
-            - v1-master-
+            - v2-{{ .Branch }}-{{ checksum "digest" }}
+            - v2-{{ .Branch }}-
+            - v2-master-
       - run:
           name: Dependencies
           command: make setup
@@ -24,7 +24,7 @@ jobs:
           name: Build
           command: make build
       - save_cache:
-          key: v1-{{ .Branch }}-{{ checksum "digest" }}
+          key: v2-{{ .Branch }}-{{ checksum "digest" }}
           paths:
             - ~/.stack
             - ./.stack-work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-11.9
+      # https://github.com/haskell-works/stack-build/blob/master/minimal/Dockerfile
+      - image: quay.io/haskell_works/stack-build-minimal
       - image: contribsys/faktory
         name: faktory
     steps:
@@ -17,6 +18,9 @@ jobs:
             - v2-{{ .Branch }}-{{ checksum "digest" }}
             - v2-{{ .Branch }}-
             - v2-master-
+      - run:
+          name: Upgrade Stack
+          command: stack upgrade
       - run:
           name: Dependencies
           command: make setup

--- a/README.lhs
+++ b/README.lhs
@@ -81,7 +81,7 @@ instance FromJSON MyJob
 workerMain = do
   settings <- envSettings
 
-  runWorker settings defaultQueue $ \job ->
+  runWorker settings $ \job ->
     -- Process your Job here
     putStrLn $ myJobMessage job
 
@@ -109,6 +109,8 @@ clientMain = do
 
 When using `envSettings`, the following variables will be used:
 
+- `FAKTORY_QUEUE`: the name of the queue to consume from. This is Worker-only,
+  for `perform`, a non-default Queue should be given by the `queue` option
 - `FAKTORY_PROVIDER`: the name of another environment variable where the
   connection string can be found. Defaults to `FAKTORY_URL`.
 - `FAKTORY_URL` (or whatever you named in `FAKTORY_PROVIDER`): connection string

--- a/README.lhs
+++ b/README.lhs
@@ -98,7 +98,7 @@ clientMain = do
   client <- newClient settings Nothing -- N.B. A WorkerId is not necessary if
                                        -- only pushing Jobs.
 
-  jobId <- perform client defaultQueue $ MyJob "Hello world"
+  jobId <- perform mempty client $ MyJob "Hello world"
 
   print jobId
 

--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -17,7 +17,7 @@ main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
   settings <- envSettings
-  runWorker settings defaultQueue $ \job -> do
+  runWorker settings $ \job -> do
     let message = jobMessage job
 
     if message == "BOOM"

--- a/examples/producer/Main.hs
+++ b/examples/producer/Main.hs
@@ -21,7 +21,7 @@ main = do
   settings <- envSettings
   bracket (newClient settings Nothing) closeClient $ \client -> do
     args <- getArgs
-    jobId <- perform client defaultQueue Job
+    jobId <- perform mempty client Job
       { jobMessage = unwords args
       }
 

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -29,7 +29,7 @@ data Job arg = Job
   , jobJobtype :: String
   , jobAt :: Maybe UTCTime
   , jobArgs :: NonEmpty arg
-  -- ^ Faktory needs to serialized args as a list, but we like a single-argument
+  -- ^ Faktory needs to serialize args as a list, but we like a single-argument
   -- interface so that's what we expose. See @'jobArg'@.
   }
   deriving Generic

--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -11,7 +11,7 @@ import Control.Exception.Safe as X
 import Control.Monad as X
 import Data.Foldable as X
 import Data.Semigroup as X ((<>))
-import Data.Text as X (Text)
+import Data.Text as X (Text, pack, unpack)
 import Data.Traversable as X
 
 threadDelaySeconds :: Int -> IO ()

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -16,7 +16,7 @@ import Data.Aeson
 import Data.Aeson.Casing
 import qualified Data.Text as T
 import Faktory.Client
-import Faktory.Job
+import Faktory.Job (Job, JobId, jobArg, jobJid)
 import Faktory.Settings
 import GHC.Generics
 import GHC.Stack

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,1 @@
----
-resolver: lts-11.9
+resolver: lts-12.9

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -22,7 +22,7 @@ spec = describe "Faktory" $ do
       void $ perform @Text mempty client "HALT"
 
     processedJobs <- newMVar ([] :: [Text])
-    runWorker settings defaultQueue $ \job -> do
+    runWorker settings $ \job -> do
       modifyMVar_ processedJobs $ pure . (job:)
       when (job == "HALT") $ throw WorkerHalt
 

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -17,9 +17,9 @@ spec = describe "Faktory" $ do
     settings <- envSettings
     bracket (newClient settings Nothing) closeClient $ \client -> do
       void $ flush client
-      void $ perform @Text client defaultQueue "a"
-      void $ perform @Text client defaultQueue "b"
-      void $ perform @Text client defaultQueue "HALT"
+      void $ perform @Text mempty client "a"
+      void $ perform @Text mempty client "b"
+      void $ perform @Text mempty client "HALT"
 
     processedJobs <- newMVar ([] :: [Text])
     runWorker settings defaultQueue $ \job -> do


### PR DESCRIPTION
**Breaking changes**: `performAt` and `performIn` now accept the varying
argument (the `time` or `diff`) first instead of last. This made their
implementations in terms of an internal `performWith` function more
natural.

**Motivating need**: we want to modify the retries attribute of a Job
to, well, prevent it from retrying on errors. This is useful for Jobs
that include some *at most once* action, such as sending an Email.

**Alternatives explored**:

1. Most minimal

   We actually have everything we need available in the public interface
   to do this already, *except* the actual fields of `Job`. So the most
   minimal change we could make to support this need would be to just
   change the export from `Job` to `Job(..)`. I decided to accept some
   of the end-user burden within the library and explore providing
   something for this use-case directly.

2. Most backwards-compatible

   I could just add `performOnce`, with no other changes.

   I decided that taking that approach would exacerbate the (admittedly
   minor) duplication issues between `performAt`, `performIn`, and
   `performOnce`, which (IMO) really ought to be variations on a theme,
   i.e. implemented in terms of a shared `performWith(M)`.

   Doing that most naturally meant moving the varying arguments in
   `performAt` and `performIn` to first position instead of last -- a
   breaking change. I chose to accept this given the library is so
   young.

3. Most flexible

   I could've *only* implemented `performWith(M)` and exported that,
   leaving it again up to the end-user to implement (something like)
   `performOnce` using it.

   This would require exporting `Job(..)` so the end-user could set
   `jobRetry`. I think if I were willing to expose more of our internals
   like that, I would've just went with Alternative (1) to begin with.