### PR TITLE
Fix Job [de-]serialization

### DIFF
--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -151,11 +151,15 @@ commandOK Client {..} cmd args = withMVar clientConnection $ \conn -> do
 
 -- | Send a command, parse the response as JSON
 commandJSON
-  :: FromJSON a => Client -> ByteString -> [ByteString] -> IO (Maybe a)
+  :: FromJSON a
+  => Client
+  -> ByteString
+  -> [ByteString]
+  -> IO (Either String (Maybe a))
 commandJSON Client {..} cmd args = withMVar clientConnection $ \conn -> do
   sendUnsafe clientSettings conn cmd args
   mByteString <- recvUnsafe clientSettings conn
-  pure $ decode =<< mByteString
+  pure $ traverse eitherDecode mByteString
 
 -- | Send a command to the Server socket
 --

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -81,7 +81,7 @@ applyOptions (JobOptions patches) = go patches
 retry :: Int -> JobOptions
 retry n = JobOptions [SetRetry n]
 
--- | Eqivalent to @'retry' (-1)@: no retries, and move to Dead on failure
+-- | Equivalent to @'retry' (-1)@: no retries, and move to Dead on failure
 once :: JobOptions
 once = retry (-1)
 

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -81,8 +81,9 @@ applyOptions (JobOptions patches) = go patches
 retry :: Int -> JobOptions
 retry n = JobOptions [SetRetry n]
 
+-- | Eqivalent to @'retry' (-1)@: no retries, and move to Dead on failure
 once :: JobOptions
-once = retry 0
+once = retry (-1)
 
 queue :: Queue -> JobOptions
 queue q = JobOptions [SetQueue q]

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -34,6 +34,7 @@ spec = describe "Faktory" $ do
     bracket (newClient settings Nothing) closeClient $ \client -> do
       void $ flush client
       void $ perform @Text once client "a"
+      void $ perform @Text (retry 0) client "b"
       void $ perform @Text mempty client "HALT"
 
     processedJobs <- newMVar ([] :: [Text])
@@ -42,4 +43,4 @@ spec = describe "Faktory" $ do
       when (job == "HALT") $ throw WorkerHalt
 
     jobs <- readMVar processedJobs
-    jobs `shouldMatchList` ["a", "HALT"]
+    jobs `shouldMatchList` ["a", "b", "HALT"]


### PR DESCRIPTION
1. Add failing test for retry options

   Something about [de-]serialization of Jobs means that when we Produce
   with options it fails to be picked up by Consumers. This test will
   drive better debug-ability and an actual fix.

1. Separate no-job from invalid-job cases

   Upgrade commandJSON to Either String (Maybe a) so JSON parsing
   failures can be captured in Left. We still need Maybe within the
   Right branch since no Job at all is a normal part of consuming and
   Nothing is a fitting representation.

   Then pass that up through fetchJob and handle the Left case
   specifically in processorLoop. We still ignore and carry on, but now
   with a log message. In an ideal world, we would attempt to re-parse
   the Job for just its Id, so we could Fail it formally rather than
   leave it to time out -- but that's very hard to do with the way the
   functions are broken up right now, so has been deferred.

1. Make Job type more faithful to the protocol

   https://github.com/contribsys/faktory/wiki/The-Job-Payload

   Re-orders the accessors to show required then optional, and makes all
   fields that are optional Maybe values. This is simpler and has less
   explicit-defaulting on our part.

1. Change the meaning of once

   From the documentation:

   > set the number of retries to perform if this job fails. Default is
   > 25 [...] A value of 0 means the job will not be retried and will
   > be discarded if it fails. A value of -1 means don't retry but move
   > the job immediately to the Dead set if it fails.

   We want our "once" Jobs to go to Dead if they fail, not lost in the
   ether. This seems like a reasonable choice generally. Users can still
   use (retry 0) to get that "original" behavior.