### PR TITLE
Add configurable delay for idle worker

### DIFF
--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -26,6 +26,7 @@ data Settings = Settings
   , settingsConnection :: ConnectionInfo
   , settingsLogDebug :: String -> IO ()
   , settingsLogError :: String -> IO ()
+  , settingsWorkerIdleDelay :: Int
   }
 
 defaultSettings :: Settings
@@ -34,6 +35,7 @@ defaultSettings = Settings
   , settingsConnection = defaultConnectionInfo
   , settingsLogDebug = \_msg -> pure ()
   , settingsLogError = hPutStrLn stderr . ("[ERROR]: " <>)
+  , settingsWorkerIdleDelay = 1
   }
 
 -- | Defaults, but read @'Connection'@ from the environment

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -76,7 +76,7 @@ processorLoop client settings f = do
 
   case emJob of
     Left err -> settingsLogError settings $ "Invalid Job: " <> err
-    Right Nothing -> threadDelaySeconds 1
+    Right Nothing -> threadDelaySeconds $ settingsWorkerIdleDelay settings
     Right (Just job) ->
       processAndAck job
         `catches` [ Handler $ \(ex :: WorkerHalt) -> throw ex


### PR DESCRIPTION
We default to 1 second as a sleep for idle work. This prevents the
process from thrashing in a tight loop. This delay may be too long or
too short for some workers. Instead we can provide a configuration
through `Settings`.

This addresses #27 