### PR TITLE
Tag faktory image on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # https://github.com/haskell-works/stack-build/blob/master/minimal/Dockerfile
       - image: quay.io/haskell_works/stack-build-minimal
-      - image: contribsys/faktory
+      - image: contribsys/faktory:0.9.0
         name: faktory
     steps:
       - checkout


### PR DESCRIPTION
Just seeing if our test suite passes with 0.9.0. See #28.

This has likely already been vetted since the implicit :latest tag would've
almost certainly been picked up as 0.9.0 in the CI run for #29. But might as
well be explicit about what we CI on, both in this test and going forward.