### PR TITLE
Add version bounds for hackage

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,7 @@ tested-with: GHC==8.4.3
 ghc-options: -Wall
 
 dependencies:
-  - "base >= 4.5 && < 5"
+  - base >= 4.11 && < 5
 
 default-extensions:
   - BangPatterns
@@ -77,20 +77,20 @@ default-extensions:
 library:
   source-dirs: library
   dependencies:
-    - aeson
-    - aeson-casing
-    - bytestring
-    - connection
-    - cryptonite
-    - megaparsec
-    - memory
-    - network
-    - random
-    - safe-exceptions
-    - scanner
-    - text
-    - time
-    - unix
+    - aeson >= 1.3 && < 2
+    - aeson-casing >= 0.1 && < 1
+    - bytestring >= 0.1 && < 1
+    - connection >= 0.2 && < 1
+    - cryptonite >= 0.2 && < 1
+    - megaparsec >= 6.5 && < 7
+    - memory >= 0.1 && < 1
+    - network >= 2.6 && < 3
+    - random >= 1.1 && < 2
+    - safe-exceptions >= 0.1 && < 1
+    - scanner >= 0.2 && < 1
+    - text >= 1.2 && < 2
+    - time >= 1.8 && < 2
+    - unix >= 2.7 && < 3
 
 executables:
   faktory-example-producer:


### PR DESCRIPTION
I added version bounds to the package by utilizing
`stack list-dependencies`. This gave me base bounds to work from. I then
placed very loose bounds on EPOCH versions.

```
$ stack list-dependencies --depth 1
aeson 1.3.1.1
aeson-casing 0.1.0.5
base 4.11.1.0
bytestring 0.10.8.2
connection 0.2.8
cryptonite 0.25
faktory 0.1.0.0
megaparsec 6.5.0
memory 0.14.16
network 2.6.3.6
random 1.1
safe-exceptions 0.1.7.0
scanner 0.2
text 1.2.3.0
time 1.8.0.2
unix 2.7.2.2
```

Without upper bounds this does actually explode. This package breaks
with `megaparsec-7.0.0.0`.