### PR TITLE
Export abstract JobOptions type

### DIFF
--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -1,6 +1,7 @@
 module Faktory.Job
   ( Job
   , JobId
+  , JobOptions
   , perform
   , retry
   , once
@@ -46,6 +47,10 @@ data JobUpdate
   | SetAt UTCTime
   | SetIn NominalDiffTime
 
+-- | Options for the execution of a job
+--
+-- See @'perform'@ for more details.
+--
 newtype JobOptions = JobOptions [JobUpdate]
   deriving newtype (Semigroup, Monoid)
 


### PR DESCRIPTION
If you have options that you're reusing in a few modules, it's nice to be able to say

```haskell
options :: JobOptions
options = queue "MyRadQueue" <> once
```

Currently, you can have a top-level definition, but you can't give it a type.