### PR TITLE
Multi-GHC CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,28 @@
 ---
 version: 2
-jobs:
-  build:
+
+references:
+  stack_build: &stack_build
     docker:
       # https://github.com/haskell-works/stack-build/blob/master/minimal/Dockerfile
       - image: quay.io/haskell_works/stack-build-minimal
       - image: contribsys/faktory:0.9.0
         name: faktory
-    environment:
-      STACK_ARGUMENTS: --no-terminal
     steps:
       - checkout
       - run:
           name: Digest
           command: |
+            {
+              stack --version
+              echo -- "$STACK_YAML/$STACK_ARGUMENTS"
+            } > rdigest
             git ls-files | xargs md5sum > digest
       - restore_cache:
           keys:
-            - v2-{{ .Branch }}-{{ checksum "digest" }}
-            - v2-{{ .Branch }}-
-            - v2-master-
+            - v3-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
+            - v3-{{ .Branch }}-
+            - v3-master-
       - run:
           name: Upgrade Stack
           command: stack upgrade
@@ -30,7 +33,8 @@ jobs:
           name: Build
           command: make build
       - save_cache:
-          key: v2-{{ .Branch }}-{{ checksum "digest" }}
+          # yamllint disable-line rule:line-length
+          key: v3-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
           paths:
             - ~/.stack
             - ./.stack-work
@@ -42,3 +46,25 @@ jobs:
           command: make test
           environment:
             FAKTORY_URL: tcp://faktory:7419
+
+jobs:
+  build:
+    <<: *stack_build
+  build_8.4.4:
+    <<: *stack_build
+    environment:
+      STACK_ARGUMENTS: --no-terminal
+      STACK_YAML: stack-lts-12.21.yaml
+  build_8.6.3:
+    <<: *stack_build
+    environment:
+      STACK_ARGUMENTS: --no-terminal
+      STACK_YAML: stack-lts-13.1.yaml
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+      - build_8.4.4
+      - build_8.6.3

--- a/package.yaml
+++ b/package.yaml
@@ -42,9 +42,10 @@ extra-doc-files:
   - CHANGELOG.md
   - README.lhs
 
-tested-with:
-  - GHC==8.4.4
-  - GHC==8.6.3
+# TODO: figuer out syntax here
+# tested-with:
+#   - GHC==8.4.4
+#   - GHC==8.6.3
 
 ghc-options:
   -Weverything

--- a/package.yaml
+++ b/package.yaml
@@ -42,7 +42,9 @@ extra-doc-files:
   - CHANGELOG.md
   - README.lhs
 
-tested-with: GHC==8.4.3
+tested-with:
+  - GHC==8.4.4
+  - GHC==8.6.3
 
 ghc-options:
   -Weverything

--- a/stack-lts-12.21.yaml
+++ b/stack-lts-12.21.yaml
@@ -1,0 +1,1 @@
+resolver: lts-12.21

--- a/stack-lts-12.21.yaml
+++ b/stack-lts-12.21.yaml
@@ -1,1 +1,3 @@
 resolver: lts-12.21
+extra-deps:
+  - megaparsec-7.0.4@sha256:a7397151601cbe6b8f831f8bdad1a10118dcd6d9a7ee50d6bbdcfbd1181b4ba2

--- a/stack-lts-13.1.yaml
+++ b/stack-lts-13.1.yaml
@@ -1,0 +1,1 @@
+resolver: lts-13.1


### PR DESCRIPTION
Actively test on current and one version back.

---

NOTEs:

(Some of this may get back into the commit message before merge.)

- I didn't touch the stack.yaml yet, and am waiting to rebase over #38. This
  means the latest-ghc build will probably also be red at first.

- A stack.yaml is still present, even though it's somewhat redundant with the
  latest-ghc-specific one, but they represent different things (default-build vs
  latest-ghc build) and so I usually do it this way since it's fine if they
  diverge, even if we choose to sync them up once in a while -- feel free to
  disagree here and I'll go the other way

- I also sometimes add a job building on nightly and trigger it for pushes and
  based on cron, but I didn't do that yet -- please let me know if you think
  that'd be valuable

  Example: https://github.com/thoughtbot/yesod-auth-oauth2/blob/master/.circleci/config.yml#L70